### PR TITLE
replaced fixed name with the variable 'annotatorname'

### DIFF
--- a/scripts/rs_new_annotator
+++ b/scripts/rs_new_annotator
@@ -117,7 +117,7 @@ def create_cpp_source(pathToPackage,annotatorName):
            "  }\n"
            "};\n\n"
            "// This macro exports an entry point that is used to create the annotator.\n"
-           "MAKE_AE(MyFirstAnnotator)");
+           "MAKE_AE("+annotatorName+")");
     f.write(txt)
     f.close()
     


### PR DESCRIPTION
For creating various annotators with different names the macro which is exporting the entry point has to be generic within the script.