### PR TITLE
mods to Plane Annotator

### DIFF
--- a/descriptors/annotators/detection/PlaneAnnotator.xml
+++ b/descriptors/annotators/detection/PlaneAnnotator.xml
@@ -10,7 +10,7 @@
     <vendor/>
     <configurationParameters>
       <configurationParameter>
-        <name>plane_estimateion_mode</name>
+        <name>plane_estimation_mode</name>
         <description>BOARD or PCL or MPS or from FILE</description>
         <type>String</type>
         <multiValued>false</multiValued>
@@ -66,7 +66,7 @@
     </configurationParameters>
     <configurationParameterSettings>
       <nameValuePair>
-        <name>plane_estimateion_mode</name>
+        <name>plane_estimation_mode</name>
         <value>
           <string>PCL</string>
         </value>

--- a/descriptors/annotators/detection/PlaneAnnotator.xml
+++ b/descriptors/annotators/detection/PlaneAnnotator.xml
@@ -10,9 +10,17 @@
     <vendor/>
     <configurationParameters>
       <configurationParameter>
-        <name>mode</name>
-        <description>BOARD or PCL or MPS</description>
+        <name>plane_estimateion_mode</name>
+        <description>BOARD or PCL or MPS or from FILE</description>
         <type>String</type>
+        <multiValued>false</multiValued>
+        <mandatory>false</mandatory>
+      </configurationParameter>
+
+      <configurationParameter>
+        <name>save_to_file</name>
+        <description>save plane model coeffs. Saves model coeffs to robosherlock/config/plane_model.xml</description>
+        <type>Boolean</type>
         <multiValued>false</multiValued>
         <mandatory>false</mandatory>
       </configurationParameter>
@@ -58,7 +66,7 @@
     </configurationParameters>
     <configurationParameterSettings>
       <nameValuePair>
-        <name>mode</name>
+        <name>plane_estimateion_mode</name>
         <value>
           <string>PCL</string>
         </value>

--- a/src/detection/src/PlaneAnnotator.cpp
+++ b/src/detection/src/PlaneAnnotator.cpp
@@ -111,10 +111,10 @@ public:
   {
     outInfo("initialize");
 
-    if(ctx.isParameterDefined("plane_estimateion_mode"))
+    if(ctx.isParameterDefined("plane_estimation_mode"))
     {
       std::string sMode;
-      ctx.extractValue("plane_estimateion_mode", sMode);
+      ctx.extractValue("plane_estimation_mode", sMode);
       outInfo("mode set to: " << sMode);
       if(sMode == "BOARD")
       {
@@ -153,7 +153,7 @@ public:
     {
       ctx.extractValue("angular_threshold_deg", angular_threshold_deg);
     }
-    if(ctx.isParameterDefined("saveToFile"))
+    if(ctx.isParameterDefined("save_to_file"))
     {
       ctx.extractValue("save_to_file", saveToFile);
     }
@@ -197,6 +197,7 @@ private:
     case FILE:
       outInfo("Loading from File");
       loadPlaneModel(tcas, scene);
+      break;
     }
 
     return UIMA_ERR_NONE;
@@ -362,7 +363,7 @@ private:
 
   void estimateFromPCL(CAS &tcas, rs::Scene &scene)
   {
-    outInfo("estimating plane form Point Cloud data");
+    outInfo("Estimating plane form Point Cloud data");
     rs::SceneCas cas(tcas);
 
     cloud = pcl::PointCloud<pcl::PointXYZRGBA>::Ptr(new pcl::PointCloud<pcl::PointXYZRGBA>());
@@ -382,6 +383,7 @@ private:
 
       if(saveToFile)
       {
+        outInfo("Saving Plane to file: "<<pathToModelFile);
         cv::Mat coeffs = cv::Mat_<float>(4, 1);
         for(uint8_t i = 0; i < planeModel.size(); ++i)
         {
@@ -608,6 +610,7 @@ private:
     case BOARD:
       output = cloud;
       break;
+    case FILE:
     case PCL:
       output.reset(new pcl::PointCloud<pcl::PointXYZRGBA>);
       ei.setInputCloud(cloud);
@@ -635,7 +638,7 @@ private:
       output->width = output->points.size();
       output->height = 1;
       output->is_dense = 1;
-      break;
+      break;    
     }
 
     if(firstRun)


### PR DESCRIPTION
* added option to save the plane coefficients. useful when working with a turn table
* renamed `mode` param to `plane_estimation_mode`  so it won't conflict anymore with `mode` from `PointCloudClusterExtractor`