### PR TITLE
added i/o for Object Id res

### DIFF
--- a/descriptors/annotators/tracker/ObjectIdentityResolution.xml
+++ b/descriptors/annotators/tracker/ObjectIdentityResolution.xml
@@ -94,10 +94,17 @@
     <capabilities>
       <capability>
         <inputs/>
-        <outputs/>
-        <languagesSupported>
-          <language>x-unspecified</language>
-        </languagesSupported>
+        <outputs>
+           <type allAnnotatorFeatures="true">rs.scene.Object</type>
+        </outputs>
+        <inputSofas>
+          <sofaName>rs.scene.MergedCluster</sofaName>
+          <sofaName>rs.annotation.Shape</sofaName>
+          <sofaName>rs.annotation.SemanticColor</sofaName>
+          <sofaName>rs.annotation.Geometry</sofaName>
+          <sofaName>rs.annotation.Detection</sofaName>
+        </inputSofas>
+        <languagesSupported/>
       </capability>
     </capabilities>
     <operationalProperties>

--- a/src/utils/include/rs/utils/RSAnalysisEngineManager.h
+++ b/src/utils/include/rs/utils/RSAnalysisEngineManager.h
@@ -58,7 +58,6 @@ public:
     {
       for(size_t i = 0; i < engines.size(); ++i)
       {
-        engines[i].resetCas();
         engines[i].process();
       }
     }
@@ -72,6 +71,7 @@ public:
     }
     for(size_t i = 0; i < engines.size(); ++i)
     {
+      engines[i].resetCas();
       engines[i].stop();
     }
   }


### PR DESCRIPTION
- planning a pipeline will add objId res now if some component needs persisting objects instead of obj hyps