### PR TITLE
fix

### DIFF
--- a/src/filter/src/RegionFilter.cpp
+++ b/src/filter/src/RegionFilter.cpp
@@ -412,7 +412,7 @@ private:
     }
     else if(region.name == "kitchen_island_counter_top")
     {
-      minY += 0.7; //same for the hot plate
+      minY += 0.6; //same for the hot plate
     }
 
     tf::Transform transform;

--- a/src/io/src/TFBroadcaster.cpp
+++ b/src/io/src/TFBroadcaster.cpp
@@ -179,7 +179,7 @@ public:
             tf::Stamped<tf::Pose> tf_stamped_pose;
             rs::conversion::from(clPart.pose(), tf_stamped_pose);
             std::stringstream ss;
-            ss<<"cluster_part_"<<clust_it - clusters.begin()<<"_"<<idx<<"_frame";
+            ss<<"rs_cluster_part_"<<clust_it - clusters.begin()<<"_"<<idx<<"_frame";
             stamped_transforms.push_back(tf::StampedTransform(tf_stamped_pose, ros::Time::now(), tf_stamped_pose.frame_id_, ss.str()));
             idx++;
           }

--- a/src/tracking/src/ObjectIdentityResolution.cpp
+++ b/src/tracking/src/ObjectIdentityResolution.cpp
@@ -526,7 +526,7 @@ private:
 
     object.annotations.allocate();
     std::vector<std::string> clusters = object.clusters();
-
+    std::vector<bool> addedClusterAnnotations(annotationsC.size(), false);
     for(size_t i = 0; i < annotationsO.size(); ++i)
     {
       rs::Annotation &annotationO = annotationsO[i];
@@ -542,12 +542,21 @@ private:
         {
           object.annotations.append(annotationC);
           merged = true;
+          addedClusterAnnotations[j] = true;
           break;
         }
       }
       if(!merged)
       {
         object.annotations.append(annotationO);
+      }
+    }
+    //add annotaation of matched Cluster that are new and not in object
+    for(size_t i = 0; i < addedClusterAnnotations.size(); ++i)
+    {
+      if(!addedClusterAnnotations[i])
+      {
+        object.annotations.append(annotationsC[i]);
       }
     }
 


### PR DESCRIPTION
- in object Id resolution, new annotations of clusters that belong to a persistent objects, will be now added to the annotations the respective persistent object