### PR TITLE
Fixed the issue that AEs get not updated properly

### DIFF
--- a/scripts/rs_create_package
+++ b/scripts/rs_create_package
@@ -48,7 +48,9 @@ echo '##########################################################################
 echo '## Find all include directories                                               ##'>> $CMakefile
 echo '################################################################################'>> $CMakefile
 echo 'find_include_dirs(RS_INCLUDE_DIRS_LIST)'>> $CMakefile
-echo 'catkin_package()'>> $CMakefile
+echo 'catkin_package('>> $CMakefile
+echo '   CFG_EXTRAS ${PROJECT_NAME}_config.cmake'>> $CMakefile
+echo '   )'>> $CMakefile
 echo '################################################################################'>> $CMakefile
 echo '## Package dependencies                                                       ##'>> $CMakefile
 echo '################################################################################'>> $CMakefile


### PR DESCRIPTION
${PROJECT_NAME}_config.cmake is need in order to get the path to the annotators for example. Without this AEs in other projects will be updated properly