### PR TITLE
Adds filtering of FeatureStructure[Array/List] for elements with certain annotations

### DIFF
--- a/src/core/include/rs/feature_structure_proxy.h
+++ b/src/core/include/rs/feature_structure_proxy.h
@@ -410,6 +410,24 @@ public:
     return success;
   }
 
+  /*
+   *    Example code:
+   *    std::vector<rs::Cluster> class_clust;
+   *    std::vector<std::vector<rs::Classification>> class_anno;
+   *
+   *    scene.identifiables.filter(class_clust, class_anno);
+   *
+   *    Explanation:
+   *
+   *    1.  std::vectorrs::Cluster class_clust;
+   *        This is the vector containing all the clusters that are found in the containing list that have the specified kind of annotation. Generally the type used for the result vector can be of any kind, but in order to use the functionality of the function it has to be a type that can contain annotations - otherwise nothing will be returned.
+   *
+   *    2.  std::vector<std::vectorpercepteros::ToolObject> class_anno;
+   *        This is the vector of vectors for all the annotations of the clusters. It has to be a vector of vectors since every cluster can have multiple annotations of the same type. The vector of annotations at index 0 corresponds to the cluster at index 0 and so on. As with the clusters above, the type of the vectors can be anything, but in order to get a result they have to be some type of annotations.
+   *
+   *    3.  scene.identifiables.filter(class_clust, class_anno);
+   *        This is the call, filtering out all of the clusters containing annotations of type Classification and the annotations they have from the list scene.identifiables
+   */
   template<typename TargetT, typename AnnotT>
   bool filter(std::vector<TargetT> &result, std::vector<std::vector<AnnotT>> &annots)
   {
@@ -697,6 +715,24 @@ public:
     return success;
   }
 
+  /*
+   *    Example code:
+   *    std::vector<rs::Cluster> class_clust;
+   *    std::vector<std::vector<rs::Classification>> class_anno;
+   *
+   *    scene.identifiables.filter(class_clust, class_anno);
+   *
+   *    Explanation:
+   *
+   *    1.  std::vectorrs::Cluster class_clust;
+   *        This is the vector containing all the clusters that are found in the containing list that have the specified kind of annotation. Generally the type used for the result vector can be of any kind, but in order to use the functionality of the function it has to be a type that can contain annotations - otherwise nothing will be returned.
+   *
+   *    2.  std::vector<std::vectorpercepteros::ToolObject> class_anno;
+   *        This is the vector of vectors for all the annotations of the clusters. It has to be a vector of vectors since every cluster can have multiple annotations of the same type. The vector of annotations at index 0 corresponds to the cluster at index 0 and so on. As with the clusters above, the type of the vectors can be anything, but in order to get a result they have to be some type of annotations.
+   *
+   *    3.  scene.identifiables.filter(class_clust, class_anno);
+   *        This is the call, filtering out all of the clusters containing annotations of type Classification and the annotations they have from the list scene.identifiables
+   */
   template<typename TargetT, typename AnnotT>
   bool filter(std::vector<TargetT> &result, std::vector<std::vector<AnnotT>> &annots)
   {

--- a/src/core/include/rs/feature_structure_proxy.h
+++ b/src/core/include/rs/feature_structure_proxy.h
@@ -422,7 +422,7 @@ public:
    *    1.  std::vectorrs::Cluster class_clust;
    *        This is the vector containing all the clusters that are found in the containing list that have the specified kind of annotation. Generally the type used for the result vector can be of any kind, but in order to use the functionality of the function it has to be a type that can contain annotations - otherwise nothing will be returned.
    *
-   *    2.  std::vector<std::vectorpercepteros::ToolObject> class_anno;
+   *    2.  std::vector<std::vector<rs::Classification>> class_anno;
    *        This is the vector of vectors for all the annotations of the clusters. It has to be a vector of vectors since every cluster can have multiple annotations of the same type. The vector of annotations at index 0 corresponds to the cluster at index 0 and so on. As with the clusters above, the type of the vectors can be anything, but in order to get a result they have to be some type of annotations.
    *
    *    3.  scene.identifiables.filter(class_clust, class_anno);
@@ -727,7 +727,7 @@ public:
    *    1.  std::vectorrs::Cluster class_clust;
    *        This is the vector containing all the clusters that are found in the containing list that have the specified kind of annotation. Generally the type used for the result vector can be of any kind, but in order to use the functionality of the function it has to be a type that can contain annotations - otherwise nothing will be returned.
    *
-   *    2.  std::vector<std::vectorpercepteros::ToolObject> class_anno;
+   *    2.  std::vector<std::vector<rs::Classification>> class_anno;
    *        This is the vector of vectors for all the annotations of the clusters. It has to be a vector of vectors since every cluster can have multiple annotations of the same type. The vector of annotations at index 0 corresponds to the cluster at index 0 and so on. As with the clusters above, the type of the vectors can be anything, but in order to get a result they have to be some type of annotations.
    *
    *    3.  scene.identifiables.filter(class_clust, class_anno);

--- a/src/core/include/rs/feature_structure_proxy.h
+++ b/src/core/include/rs/feature_structure_proxy.h
@@ -409,6 +409,41 @@ public:
 
     return success;
   }
+
+  template<typename TargetT, typename AnnotT>
+  bool filter(std::vector<TargetT> &result, std::vector<std::vector<AnnotT>> &annots)
+  {
+    bool success = false;
+
+    if(has())
+    {
+      typename trait::ArrayFSType arrayfs = _get();
+      result.reserve(arrayfs.size());
+
+      uima::Type type = rs::type<TargetT>(this->fs().getCAS());
+
+      for(size_t idx = 0; idx < arrayfs.size(); ++idx)
+      {
+        uima::FeatureStructure fs = arrayfs.get(idx);
+
+        if(fs.getType() == type)
+        {
+          std::vector<AnnotT> clustannots;
+          TargetT cluster(fs);
+          cluster.annotations.filter(clustannots);
+
+          if(clustannots.size() > 0)
+          {
+            success = true;
+            result.push_back(cluster);
+            annots.push_back(clustannots);
+          }
+        }
+      }
+    }
+
+    return success;
+  }
 };
 
 template<typename T, typename TAllocator>
@@ -653,6 +688,42 @@ public:
           success = true;
           TargetT elem(fs);
           result.push_back(elem);
+        }
+
+        listfs = listfs.getTail();
+      }
+    }
+
+    return success;
+  }
+
+  template<typename TargetT, typename AnnotT>
+  bool filter(std::vector<TargetT> &result, std::vector<std::vector<AnnotT>> &annots)
+  {
+    bool success = false;
+
+    if(!empty())
+    {
+      typename trait::ListType listfs = _get();
+
+      uima::Type type = rs::type<TargetT>(this->fs().getCAS());
+
+      while(!listfs.isEmpty())
+      {
+        uima::FeatureStructure fs = listfs.getHead();
+
+        if(fs.getType() == type)
+        {
+          std::vector<AnnotT> clustannots;
+          TargetT cluster(fs);
+          cluster.annotations.filter(clustannots);
+
+          if(clustannots.size() > 0)
+          {
+            success = true;
+            result.push_back(cluster);
+            annots.push_back(clustannots);
+          }
         }
 
         listfs = listfs.getTail();


### PR DESCRIPTION
Up to now, it was only possible to get all elements in the scene with a certain type. This pull requests includes two methods to filter FeatureStructure[Arrays/Lists] to get all elements of a certain type with annotations of a certain type. The elements and their fitting annotations are returned in a vector and a vector of vectors, respectively.