### PR TITLE
fix for issue #94

### DIFF
--- a/src/io/include/rs/io/ROSCamInterface.h
+++ b/src/io/include/rs/io/ROSCamInterface.h
@@ -48,7 +48,6 @@ protected:
   double maxViewpointDistance, maxViewpointRotation;
 
   std::mutex lock;
-  uint64_t prevTS;
 public:
   ~ROSCamInterface();
 

--- a/src/io/include/rs/io/ROSCamInterface.h
+++ b/src/io/include/rs/io/ROSCamInterface.h
@@ -48,7 +48,7 @@ protected:
   double maxViewpointDistance, maxViewpointRotation;
 
   std::mutex lock;
-
+  uint64_t prevTS;
 public:
   ~ROSCamInterface();
 

--- a/src/io/include/rs/io/ROSKinectBridge.h
+++ b/src/io/include/rs/io/ROSKinectBridge.h
@@ -71,7 +71,7 @@ public:
   ROSKinectBridge(const boost::property_tree::ptree &pt);
   ~ROSKinectBridge();
 
-  bool setData(uima::CAS &tcas, u_int64_t = std::numeric_limits<uint64_t>::max());
+  bool setData(uima::CAS &tcas, uint64_t = std::numeric_limits<uint64_t>::max());
   inline void getColorImage(cv::Mat& c)
   {
     c = this->color.clone();

--- a/src/io/include/rs/io/Storage.h
+++ b/src/io/include/rs/io/Storage.h
@@ -77,6 +77,7 @@ private:
 
   void removeView(const ::mongo::BSONElement &elem);
 
+
 public:
   Storage();
   Storage(const Storage &other);
@@ -100,6 +101,8 @@ public:
   void loadCollection(uima::CAS &cas, const std::string &view, const std::string &collection);
 
   std::vector<Cluster> getClusters(uima::CAS &cas, const std::string &collection, std::vector<std::string> ids);
+
+  uint64_t prevTS;
 };
 
 } // namespace rs

--- a/src/io/include/rs/io/Storage.h
+++ b/src/io/include/rs/io/Storage.h
@@ -101,8 +101,6 @@ public:
   void loadCollection(uima::CAS &cas, const std::string &view, const std::string &collection);
 
   std::vector<Cluster> getClusters(uima::CAS &cas, const std::string &collection, std::vector<std::string> ids);
-
-  uint64_t prevTS;
 };
 
 } // namespace rs

--- a/src/io/src/ROSCamInterface.cpp
+++ b/src/io/src/ROSCamInterface.cpp
@@ -24,7 +24,7 @@
 // Implementation
 
 ROSCamInterface::ROSCamInterface(const boost::property_tree::ptree &pt)
-  : CamInterface(pt), spinner(0), nodeHandle("~"), prevTS(0)
+  : CamInterface(pt), spinner(0), nodeHandle("~")
 {
   listener = new tf::TransformListener(nodeHandle, ros::Duration(10.0));
   tfFrom = pt.get<std::string>("tf.from");
@@ -89,14 +89,5 @@ void ROSCamInterface::setTransformAndTime(uima::CAS &tcas)
     scene.viewPoint.set(vp);
     outInfo("added viewpoint to scene");
   }
-  uint64 currentTS = timestamp.toNSec();
-  uint64 diff = currentTS-prevTS;
-  outDebug("Diff: "<<diff<<" (ns)" );
-  if(prevTS != 0 && currentTS - prevTS == 0)
-  {
-    outError("Waht the fuck just happened?");
-  }
-  prevTS = currentTS;
-
   scene.timestamp.set(timestamp.toNSec());
 }

--- a/src/io/src/ROSCamInterface.cpp
+++ b/src/io/src/ROSCamInterface.cpp
@@ -49,8 +49,6 @@ ROSCamInterface::~ROSCamInterface()
 
 bool ROSCamInterface::lookupTransform(const ros::Time &timestamp)
 {
-  this->timestamp = timestamp;
-
   if(lookUpViewpoint)
   {
     try

--- a/src/io/src/ROSCameraBridge.cpp
+++ b/src/io/src/ROSCameraBridge.cpp
@@ -99,6 +99,7 @@ void ROSCameraBridge::cb_(const sensor_msgs::Image::ConstPtr rgb_img_msg,
   color = orig_rgb_img->image.clone();
 
   lock.lock();
+  this->timestamp = cameraInfo.header.stamp;
   this->color = color;
   this->cameraInfo = cameraInfo;
   _newData = true;
@@ -120,10 +121,9 @@ bool ROSCameraBridge::setData(uima::CAS &tcas, uint64_t ts)
   color = this->color;
   cameraInfo = this->cameraInfo;
   _newData = false;
-  lock.unlock();
-
   rs::SceneCas cas(tcas);
   setTransformAndTime(tcas);
+  lock.unlock();
 
   cas.set(VIEW_COLOR_IMAGE_HD, color);
   cas.set(VIEW_COLOR_IMAGE, color);

--- a/src/io/src/ROSKinectBridge.cpp
+++ b/src/io/src/ROSKinectBridge.cpp
@@ -66,9 +66,9 @@ void ROSKinectBridge::readConfig(const boost::property_tree::ptree &pt)
   image_transport::TransportHints hintsColor(color_hints);
   image_transport::TransportHints hintsDepth(depth_hints);
 
-  depthImageSubscriber = new image_transport::SubscriberFilter(it, depth_topic, 5, hintsDepth);
-  rgbImageSubscriber = new image_transport::SubscriberFilter(it, color_topic, 5, hintsColor);
-  cameraInfoSubscriber = new message_filters::Subscriber<sensor_msgs::CameraInfo>(nodeHandle, cam_info_topic, 5);
+  depthImageSubscriber = new image_transport::SubscriberFilter(it, depth_topic, 1, hintsDepth);
+  rgbImageSubscriber = new image_transport::SubscriberFilter(it, color_topic, 1, hintsColor);
+  cameraInfoSubscriber = new message_filters::Subscriber<sensor_msgs::CameraInfo>(nodeHandle, cam_info_topic, 1);
 
   outInfo("  Depth topic: " FG_BLUE << depth_topic);
   outInfo("  Color topic: " FG_BLUE << color_topic);
@@ -203,6 +203,7 @@ void ROSKinectBridge::cb_(const sensor_msgs::Image::ConstPtr rgb_img_msg,
 
   lock.lock();
 
+  this->timestamp = cameraInfo.header.stamp;
   this->color = color;
   this->depth = depth;
   this->cameraInfo = cameraInfo;
@@ -211,7 +212,6 @@ void ROSKinectBridge::cb_(const sensor_msgs::Image::ConstPtr rgb_img_msg,
     this->cameraInfoHD = cameraInfoHD;
   }
   _newData = true;
-  //  outWarn("new data");
 
   lock.unlock();
 }
@@ -236,10 +236,9 @@ bool ROSKinectBridge::setData(uima::CAS &tcas, uint64_t ts)
     cameraInfoHD = this->cameraInfoHD;
   }
   _newData = false;
-  lock.unlock();
-
   rs::SceneCas cas(tcas);
   setTransformAndTime(tcas);
+  lock.unlock();
 
   if(scale && color.cols >= 1280)
   {

--- a/src/io/src/ROSTangoBridge.cpp
+++ b/src/io/src/ROSTangoBridge.cpp
@@ -193,6 +193,7 @@ void ROSTangoBridge::cb_(const sensor_msgs::Image::ConstPtr color_img_msg,
     }
 
     lock.lock();
+    this->timestamp = colorCameraInfo.header.stamp;
     this->color = color;
     this->colorCameraInfo = colorCameraInfo;
     this->cloud_color = cloud_color;
@@ -260,11 +261,12 @@ bool ROSTangoBridge::setData(uima::CAS &tcas, uint64_t ts)
   outInfo("  Cloud Width: " FG_BLUE << cloud_color.width);
   outInfo("  Cloud Height: " FG_BLUE << cloud_color.height);
   outInfo("  Number of Point Cloud: " FG_BLUE << cloud_color.size());
+
   _newData = false;
-  lock.unlock();
 
   rs::SceneCas cas(tcas);
   setTransformAndTime(tcas);
+  lock.unlock();
 
   cas.set(VIEW_CLOUD, cloud_color);
   cas.set(VIEW_COLOR_IMAGE, color);

--- a/src/io/src/Storage.cpp
+++ b/src/io/src/Storage.cpp
@@ -49,7 +49,6 @@ using namespace rs;
 
 Storage::Storage() : dbHost(DB_HOST), dbName(DB_NAME), dbBase(dbName + "."), dbCAS(dbBase + DB_CAS), dbScripts(dbBase + DB_SCRIPTS), first(true)
 {
-  prevTS=0;
 }
 
 Storage::Storage(const Storage &other)
@@ -211,7 +210,6 @@ bool Storage::readFS(uima::FeatureStructure fs, mongo::BSONObjBuilder &builderCA
     outDebug("storing sofas to " << dbCollection << ".");
     db.insert(dbCollection, object);
   }
-
 
   return true;
 }

--- a/src/io/src/Storage.cpp
+++ b/src/io/src/Storage.cpp
@@ -49,6 +49,7 @@ using namespace rs;
 
 Storage::Storage() : dbHost(DB_HOST), dbName(DB_NAME), dbBase(dbName + "."), dbCAS(dbBase + DB_CAS), dbScripts(dbBase + DB_SCRIPTS), first(true)
 {
+  prevTS=0;
 }
 
 Storage::Storage(const Storage &other)
@@ -353,8 +354,7 @@ bool Storage::storeScene(uima::CAS &cas, const uint64_t &timestamp)
 
     const std::string sofaId = sofa.getSofaID().asUTF8();
 
-    //if sofa should not be stored or it's the cam info and it has already been stored
-    if(!storeViews[sofaId]) //|| ((sofaId == "camera_info" || sofaId == "camera_info_hd") && !first))
+    if(!storeViews[sofaId])
     {
       outInfo("skipping sofa \"" << sofaId << "\".");
       continue;
@@ -396,6 +396,7 @@ bool Storage::removeScene(const uint64_t &timestamp)
       if(name[0] != '_')
       {
         outDebug("removing view: " << name);
+
         removeView(elem);
       }
     }

--- a/src/io/src/StorageWriter.cpp
+++ b/src/io/src/StorageWriter.cpp
@@ -35,10 +35,8 @@ private:
   std::string db;
   rs::Storage storage;
 
-  uint64_t prevTS;
-
 public:
-  StorageWriter() : host(DB_HOST), db(DB_NAME), prevTS(0)
+  StorageWriter() : host(DB_HOST), db(DB_NAME)
   {
   }
 
@@ -104,12 +102,7 @@ public:
     rs::SceneCas cas(tcas);
     rs::Scene scene = cas.getScene();
     const uint64_t timestamp = (uint64_t)scene.timestamp();
-    if(prevTS != 0 && timestamp - prevTS == 0)
-    {
-      outWarn("Catching bug: previous timestamp same as current one!!! This can not be!!! Exiting");
-      return UIMA_ERR_NONE;
-    }
-    prevTS = timestamp;
+
     if(scene.id().empty())
     {
       storage.storeScene(*tcas.getBaseCas(), timestamp);

--- a/src/io/src/StorageWriter.cpp
+++ b/src/io/src/StorageWriter.cpp
@@ -35,8 +35,10 @@ private:
   std::string db;
   rs::Storage storage;
 
+  uint64_t prevTS;
+
 public:
-  StorageWriter() : host(DB_HOST), db(DB_NAME)
+  StorageWriter() : host(DB_HOST), db(DB_NAME), prevTS(0)
   {
   }
 
@@ -82,7 +84,7 @@ public:
     for(size_t i = 0; i < enableViews.size(); ++i)
     {
       storage.enableViewStoring(*enableViews[i], true);
-      outInfo(i<<" : "<<*enableViews[i]);
+      outInfo(i << " : " << *enableViews[i]);
     }
 
     return UIMA_ERR_NONE;
@@ -102,7 +104,12 @@ public:
     rs::SceneCas cas(tcas);
     rs::Scene scene = cas.getScene();
     const uint64_t timestamp = (uint64_t)scene.timestamp();
-
+    if(prevTS != 0 && timestamp - prevTS == 0)
+    {
+      outWarn("Catching bug: previous timestamp same as current one!!! This can not be!!! Exiting");
+      return UIMA_ERR_NONE;
+    }
+    prevTS = timestamp;
     if(scene.id().empty())
     {
       storage.storeScene(*tcas.getBaseCas(), timestamp);

--- a/src/utils/src/ImagePreprocessor.cpp
+++ b/src/utils/src/ImagePreprocessor.cpp
@@ -77,11 +77,9 @@ private:
   ros::NodeHandle nh_;
   ros::Publisher pub_;
 
-  uint64_t prevTS_;
-
 public:
   ImagePreprocessor() : DrawingAnnotator(__func__), borderErosion(6), borderDilation(12),
-    pointSize(1), displayMode(MASK), pclDispMode(PCL_RGBD), nh_("~"),prevTS_(0)
+    pointSize(1), displayMode(MASK), pclDispMode(PCL_RGBD), nh_("~")
   {
     cloud = pcl::PointCloud<pcl::PointXYZRGBA>::Ptr(new pcl::PointCloud<pcl::PointXYZRGBA>);
     thermalCloud = pcl::PointCloud<pcl::PointXYZRGBA>::Ptr(new pcl::PointCloud<pcl::PointXYZRGBA>);
@@ -145,13 +143,6 @@ public:
     MEASURE_TIME;
     outInfo("process start");
     rs::SceneCas cas(tcas);
-
-    const uint64_t timestamp = (uint64_t)cas.getScene().timestamp();
-    if(prevTS_ != 0 && timestamp - prevTS_ == 0)
-    {
-      outWarn("Catching bug: previous timestamp same as current one!!! This can not be!!! Exiting");
-    }
-    prevTS_=timestamp;
 
     if(useKinect)
     {

--- a/src/utils/src/ImagePreprocessor.cpp
+++ b/src/utils/src/ImagePreprocessor.cpp
@@ -77,9 +77,11 @@ private:
   ros::NodeHandle nh_;
   ros::Publisher pub_;
 
+  uint64_t prevTS_;
+
 public:
   ImagePreprocessor() : DrawingAnnotator(__func__), borderErosion(6), borderDilation(12),
-    pointSize(1), displayMode(MASK), pclDispMode(PCL_RGBD), nh_("~")
+    pointSize(1), displayMode(MASK), pclDispMode(PCL_RGBD), nh_("~"),prevTS_(0)
   {
     cloud = pcl::PointCloud<pcl::PointXYZRGBA>::Ptr(new pcl::PointCloud<pcl::PointXYZRGBA>);
     thermalCloud = pcl::PointCloud<pcl::PointXYZRGBA>::Ptr(new pcl::PointCloud<pcl::PointXYZRGBA>);
@@ -143,6 +145,13 @@ public:
     MEASURE_TIME;
     outInfo("process start");
     rs::SceneCas cas(tcas);
+
+    const uint64_t timestamp = (uint64_t)cas.getScene().timestamp();
+    if(prevTS_ != 0 && timestamp - prevTS_ == 0)
+    {
+      outWarn("Catching bug: previous timestamp same as current one!!! This can not be!!! Exiting");
+    }
+    prevTS_=timestamp;
 
     if(useKinect)
     {


### PR DESCRIPTION
- issue #94 was hard to test as the behavior was not determenistic, hence it could still be buggy though I did not notice the equal timestamps anymore and cam info did not get deleted in a considerable amount of tests
- fixed by removing the setting of the timestamp from the lookupTransfrom and syncing it to the  camInfo/images 
