### PR TITLE
Fix a bug where threshold filtering returned incorrect results

### DIFF
--- a/src/queryanswering/src/QueryInterface.cpp
+++ b/src/queryanswering/src/QueryInterface.cpp
@@ -175,9 +175,10 @@ bool QueryInterface::checkThresholdOnList(rapidjson::Value &list, const float th
       {
         if(listIt->value.GetDouble() >= threshold)
           return true;
-        else if(listIt->value.GetDouble() < threshold)
-          return true;
       }
+      else if(listIt->value.GetDouble() < threshold)
+          return true;
+
     }
   }
   return false;


### PR DESCRIPTION
This pull request fixes a bug where filtering a list using a threshold returned incorrect objects.