### PR TITLE
Revert "Add result advertiser to service callback"

### DIFF
--- a/src/flowcontrol/include/rs/flowcontrol/RSProcessManager.h
+++ b/src/flowcontrol/include/rs/flowcontrol/RSProcessManager.h
@@ -14,7 +14,6 @@
 
 #include <robosherlock_msgs/SetRSContext.h>
 #include <robosherlock_msgs/RSQueryService.h>
-#include <robosherlock_msgs/RSObjectDescriptions.h>
 #include <robosherlock_msgs/RSVisControl.h>
 
 #include <mongo/client/dbclient.h>
@@ -44,7 +43,6 @@ public:
   ros::NodeHandle nh_;
   ros::ServiceServer service, singleService, setContextService, jsonService, visService;
 
-  ros::Publisher result_pub;
 
   bool waitForServiceCall_;
   const bool useVisualizer_;

--- a/src/flowcontrol/src/RSProcessManager.cpp
+++ b/src/flowcontrol/src/RSProcessManager.cpp
@@ -23,7 +23,6 @@ RSProcessManager::RSProcessManager(const bool useVisualizer, const bool &waitFor
     resourceManager.setLoggingLevel(uima::LogStream::EnMessage);
     break;
   }
-  result_pub = nh_.advertise<robosherlock_msgs::RSObjectDescriptions>(std::string("result_advertiser"), 1);
 
   setContextService = nh_.advertiseService("set_context", &RSProcessManager::resetAECallback, this);
 
@@ -283,10 +282,6 @@ bool RSProcessManager::handleQuery(std::string &request, std::vector<std::string
     }
 
     result.insert(result.end(), filteredResponse.begin(), filteredResponse.end());
-
-    robosherlock_msgs::RSObjectDescriptions objDescriptions;
-    objDescriptions.obj_descriptions = result;
-    result_pub.publish(objDescriptions);
 
     processing_mutex_.unlock();
     return true;


### PR DESCRIPTION
This reverts commit 61d5a1d565ff9883c2c032c4bacf3d43236a0553.
This commit causes error when I load `ResultAdvertiser` because of namespace `result_advertiser` conflict.
IMO, we don't need to advertise the result topic in RSProcess, or use another namespace.
cc. @Surxz @bbferka