### PR TITLE
[rs.launch] set arg wait default false

### DIFF
--- a/launch/rs.launch
+++ b/launch/rs.launch
@@ -8,7 +8,7 @@
   <!-- Path to where images and point clouds should be stored -->
   <arg name="save_path"        default=""/>
   <arg name="withIDRes"        default="false"/>
-  <arg name="wait"             default="true"/>
+  <arg name="wait"             default="false"/>
 
   <!-- Machine on with the nodes should run. -->
   <arg name="machine"          default="localhost"/>


### PR DESCRIPTION
In order to keep rs.launch action as previous, default value should be `false`.