### PR TITLE
make dependency installation more ROS complient

### DIFF
--- a/robosherlock/package.xml
+++ b/robosherlock/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>robosherlock</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>The RoboSherlock package</description>
 
   <maintainer email="balintbe@cs.uni-bremen.de">Ferenc Balint-Benczedi</maintainer>
@@ -18,6 +18,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <!-- ROS package ependencies -->
   <depend>rospy                      </depend>
   <depend>cv_bridge                  </depend>
   <depend>cmake_modules              </depend>
@@ -35,11 +36,15 @@
   <depend>pcl_ros		     </depend>
   <depend>pcl_conversions	     </depend>
 
-  <depend>uimacpp_ros                </depend>
+  <!--local dependencies-->
   <depend>robosherlock_msgs          </depend>
-<!--  <depend>libmongocxx_ros            </depend>-->
-  
+  <depend>uimacpp_ros                </depend>
   <depend>rapidjson_ros		     </depend>
+  
+  <!--system-->
+  <!--depend>rapidjson-dev              </depend-->
+  <depend>libmongoclient-dev         </depend>
+  <depend>mongodb 		     </depend>
   <depend>yaml-cpp                   </depend>
   <depend>swi-prolog		     </depend>
   

--- a/uimacpp_ros/cmake/FindJNI.cmake
+++ b/uimacpp_ros/cmake/FindJNI.cmake
@@ -187,6 +187,7 @@ JAVA_APPEND_LIBRARY_DIRECTORIES(JAVA_AWT_LIBRARY_DIRECTORIES
   /usr/lib/jvm/default/jre/lib/{libarch}
   /usr/lib/jvm/default/lib/{libarch}
   # Ubuntu specific paths for default JVM
+  /usr/lib/jvm/java-11-openjdk-{libarch}/jre/lib/{libarch}     # Ubuntu 15.10
   /usr/lib/jvm/java-8-openjdk-{libarch}/jre/lib/{libarch}     # Ubuntu 15.10
   /usr/lib/jvm/java-7-openjdk-{libarch}/jre/lib/{libarch}     # Ubuntu 15.10
   /usr/lib/jvm/java-6-openjdk-{libarch}/jre/lib/{libarch}     # Ubuntu 15.10

--- a/uimacpp_ros/package.xml
+++ b/uimacpp_ros/package.xml
@@ -10,4 +10,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <!--system deps-->
+  <depend>xerces</depend>
+  <depend>libicu-dev</depend>
+  <depend>apr</depend>
+  <depend>java</depend>
 </package>


### PR DESCRIPTION
Most dependencies can be installed this way using rosdep install --ignore-src --from-src . 
This brings the project closer to a release as a debian package through ROS.

This will not install the mongo client. The only solution I currently see for that is to maintain two separate branches for kinetic and melodic :disappointed: 