### PR TITLE
removing space from storage pipeline name

### DIFF
--- a/robosherlock/descriptors/analysis_engines/storage.yaml
+++ b/robosherlock/descriptors/analysis_engines/storage.yaml
@@ -1,5 +1,5 @@
 ae:
-  name: Storage pipeline
+  name: StoragePipeline
 fixedflow:
   - CollectionReader
   - ImagePreprocessor


### PR DESCRIPTION
To avoid problems when starting the pipeline and announcing the associated services (are including the pipeline names). ROS services are not allowed to have spaces in them.